### PR TITLE
Upgraded sbt from 0.13.5 to 0.13.7

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.5
+sbt.version=0.13.7


### PR DESCRIPTION
One of the very first action instructions from book is to get examples, and run "sbt test" on the examples project. On Mac with Java 7, build fails with something like

```
[error] (*:testListeners) java.net.UnknownHostException: MacBook-Pro.local: MacBook-Pro.local: nodename nor servname provided, or not known
```

If I'm not mistaken, this is manifestation of this sbt/sbt#1506 sbt bug. Root cause seems to be [this bug in Java 7](http://bugs.java.com/bugdatabase/view_bug.do?bug_id=7180557).

This patch upgrades sbt from 0.13.5 to 0.13.7 as it has the workaround/fix for the issue (see sbt/sbt#1512).