### PR TITLE
add implicit keywords

### DIFF
--- a/src/main/scala/progscala2/implicits/type-classes-subtyping2.sc
+++ b/src/main/scala/progscala2/implicits/type-classes-subtyping2.sc
@@ -12,7 +12,7 @@ trait ToJSON[+T] {
     (INDENTATION * level, INDENTATION * (level+1))
 }
 
-class AddressToJSON(address: Address) extends ToJSON[Address] {
+implicit class AddressToJSON(address: Address) extends ToJSON[Address] {
   def toJSON(level: Int = 0): String = {
     val (outdent, indent) = indentation(level)
     s"""{
@@ -24,7 +24,7 @@ class AddressToJSON(address: Address) extends ToJSON[Address] {
   }
 }
 
-class PersonToJSON(person: Person) extends ToJSON[Person] {
+implicit class PersonToJSON(person: Person) extends ToJSON[Person] {
   def toJSON(level: Int = 0): String = {
     val (outdent, indent) = indentation(level)
     s"""{


### PR DESCRIPTION
Without these implicit keywords, the following line of code can't be
compiled:

val list2: List[ToJSON[_]] = List(a, Person("Buck Trends", 29, a))