### PR TITLE
Now supports 2.13.0-RC2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ project/target
 target
 .metals
 .vscode
+.bloop/

--- a/README.markdown
+++ b/README.markdown
@@ -4,15 +4,15 @@
 
 *Dean Wampler*<br/>
 *August 11, 2014*<br/>
-*May 27, 2019* - Updated for Scala 2.12 (with preliminary support for 2.13)
+*May 27, 2019* - Updated for Scala 2.12 and 2.13
 
 [![Join the chat at https://gitter.im/deanwampler/prog-scala-2nd-ed-code-examples](https://badges.gitter.im/deanwampler/prog-scala-2nd-ed-code-examples.svg)](https://gitter.im/deanwampler/prog-scala-2nd-ed-code-examples?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 This archive contains all the code examples found in [Programming Scala, Second Edition](http://shop.oreilly.com/product/0636920033073.do), with the exception of some trivial code snippets in the text. There are also some examples in this distribution that aren't actually in the book.
 
-When the book was published, the examples used Scala 2.11. The code was recently updated to also compile with Scala 2.12.8 and (mostly) 2.13.0-RC2. The examples are unchanged, except where necessary to compile with these newer versions and with the stricter compiler flags now used.
+When the book was published, the examples used Scala 2.11. The code was recently updated to also compile with Scala 2.12.8 and 2.13.0-RC2. The examples are mostly unchanged, except where necessary to compile with these newer versions and with the stricter compiler flags now used.
 
-If you want the original code (with a few bug fixes), download the tagged `2.1.0` build or check out the `release-2.1.0` branch. The `2.2.0` release and `release-2.2.0` branch include all the updates for 2.12. The project doesn't yet compile fully with Scala 2.13; we need a stable release of ScalaTest that is at least API-compatible across all three versions.
+If you want the original code (with a few bug fixes), download the tagged `2.1.0` build or check out the `release-2.1.0` branch. The `2.3.0` release and `release-2.3.0` branch include all the updates for 2.12 and 2.13.
 
 ## How the Code Is Used in the Book
 
@@ -23,6 +23,8 @@ In the book's text, when an example corresponds to a file in this distribution, 
 ```
 
 And similarly for Java files (yes, there are Java files!). Following the usual conventions, tests are in `src/test/...`.
+
+> **NOTE:** When I upgraded support for 2.12 and 2.13, a few of the `*.scala` files were converted to `*.sc` script files (see below), because they are no long compilable as is with the new, stricter compile flags I'm using.
 
 Use these comments to find the corresponding source file. This archive also contains *ScalaTest* and *ScalaCheck* unit tests to validate some of the code. Most of these tests are not reproduced in the text of the book, except when discussing testing itself.
 
@@ -43,21 +45,25 @@ Follow these [installation instructions](http://www.scala-sbt.org/release/docs/G
 
 If you want to install Scala separately and *Scaladocs* (recommended), go to [scala-lang.org](http://scala-lang.org), but this isn't strictly required.
 
-### Editors, Eclipse, and IntelliJ
+### Editors, IntelliJ, Visual Studio Code, and Other IDEs
 
-Most editors and IDEs now include Scala plugins. For Eclipse, see the [Scala IDE](http://scala-ide.org) project. For IntelliJ use the plugin browser to find and install the Scala plugin. For NetBeans, see the [Scala page](http://wiki.netbeans.org/Scala) in their wiki. For other editors, Google is your friend. ;)
+Most editors and IDEs now have some sort of Scala support:
 
-After installing the required plugin, to load this project in your IDE, IntelliJ can import the SBT project directly. For eclipse, run `sbt eclipse` task to generate project files, then import them. For Netbeans, see the [Scala wiki page](http://wiki.netbeans.org/Scala).
+* [IntelliJ](https://www.jetbrains.com/idea/): Either the Community or Ultimate additions will work. Install the Scala plugin, which has built-in support for SBT.
+* [Visual Studio Code](https://code.visualstudio.com/): Use the new [Scala Metals](https://scalameta.org/metals/) plugin instead of older plugins.
+* [Eclipse Scala IDE](http://scala-ide.org): Old, no longer recommended.
+
+For other IDEs and text editors, try [Scala Metals](https://scalameta.org/metals/) first (I've used it with [Sublime Text](https://www.sublimetext.com/), for example) or [ENSIME](http://ensime.github.io/). You may also need additional, third-party tools for syntax highlighting, etc.
+
+After installing the required plugins, load this project in your IDE, which should detect and use the SBT project automatically. For eclipse, run the `sbt eclipse` task to generate project files, then import them.
 
 ## Building the Code Examples
 
-After installing SBT, open a command/terminal window and run the `sbt test` command.
+After installing SBT, open a command/terminal window and run the `sbt test` command. By default, it now uses Scala 2.12.8. To build and test for Scala 2.11, 2.12, and 2.13, run `sbt +test`.
 
-There will be a *lot* of output as it downloads all the dependencies, both internal to the tools and explicitly defined for the code examples.
+You'll see lots of output as it downloads all the dependencies, compiles the code and runs the tests. You should see `[success]` messages at the end.
 
-After resolving dependencies, the code will be compiled and tested. You should see only success messages.
-
-SBT is discussed in more detail in the book, but a few other commands are worth mentioning here.
+SBT is discussed in more detail in the book and the [SBT website](https://www.scala-sbt.org/), but a few useful commands are worth mentioning here.
 
 If you start `sbt` without any arguments, it puts you into an interactive mode where you can type commands. Use control-D to exit this mode. Once at the SBT prompt (a `>`), try the following commands, where each `#` starts a comment; don't type those!
 
@@ -84,6 +90,13 @@ For example, if build artifacts are required on the class path, use the followin
 
 Usually, the best way to run the scripts is to start `sbt` and run `console` to start the Scala REPL with all the dependencies added to the classpath. Then, use the REPL `:load src/main/scala/.../foo.sc` to load and run the script.
 
-## Feedback ##
+## Feedback
 
-I welcome feedback on the examples. Please post comments, corrections, etc. at the books site, [Programming Scala, Second Edition](http://shop.oreilly.com/product/0636920033073.do), or you can post feedback on the [O'Reilly forum](http://forums.oreilly.com/). There is also a dedicated site for the book where occasional updates, clarifications, corrections, and lame excuses will be posted: [programming-scala.org](http://programming-scala.org).
+I welcome feedback on the Book and these examples. Please post comments, corrections, etc. to one of the following places:
+
+* The book site, [Programming Scala, Second Edition](http://shop.oreilly.com/product/0636920033073.do)
+* The [O'Reilly forum](http://forums.oreilly.com/)
+* This GitHub repo's [Gitter channel](https://gitter.im/deanwampler/prog-scala-2nd-ed-code-examples) or [Issues](https://github.com/deanwampler/prog-scala-2nd-ed-code-examples/issues)
+* The book's Twitter account, [@ProgScala](https://twitter.com/ProgScala)
+
+There is also a dedicated site for the book where occasional updates, clarifications, corrections, and lame excuses will be posted: [programming-scala.org](http://programming-scala.org).

--- a/build.sbt
+++ b/build.sbt
@@ -5,14 +5,14 @@ version := "2.2"
 organization := "org.programming-scala"
 
 scalaVersion := "2.12.8"
-crossScalaVersions := Seq("2.11.12", "2.12.8") // 2.13 is not yet supported; need a stable scalatest, "2.13.0-RC2")
+crossScalaVersions := Seq("2.11.12", "2.12.8", "2.13.0-RC2")
 
 libraryDependencies ++= {
   lazy val versions =
     CrossVersion.partialVersion(scalaVersion.value) match {
-      case Some((2, 11)) => Map("async" -> "0.9.7",  "scalatest" -> "3.0.5",        "akka" -> "2.5.22")
-      case Some((2, 12)) => Map("async" -> "0.10.0", "scalatest" -> "3.0.5",        "akka" -> "2.5.22")
-      case Some((2, 13)) => Map("async" -> "0.10.0", "scalatest" -> "3.1.0-SNAP11", "akka" -> "2.6.0-M2")
+      case Some((2, 11)) => Map("async" -> "0.9.7",  "akka" -> "2.5.22")
+      case Some((2, 12)) => Map("async" -> "0.10.0", "akka" -> "2.5.22")
+      case Some((2, 13)) => Map("async" -> "0.10.0", "akka" -> "2.6.0-M2")
       case Some((m, n))  => println(s"Unrecognized compiler version $m.$n"); sys.exit(1)
       case None          => println("CrossVersion.partialVersion(scalaVersion.value) returned None!!"); sys.exit(1)
     }
@@ -26,7 +26,7 @@ libraryDependencies ++= {
     "ch.qos.logback"          % "logback-classic" % "1.2.3",
     "org.scalaz"             %% "scalaz-core"     % "7.2.27",
     "org.scalacheck"         %% "scalacheck"      % "1.14.0" % "test",
-    "org.scalatest"          %% "scalatest"       % versions("scalatest") % "test",
+    "org.scalatest"          %% "scalatest"       % "3.0.8-RC4" % "test", // threading the needle on versions...
     "org.specs2"             %% "specs2-core"     % "4.5.1"  % "test",
     // JUnit is used for some Java interop. examples. A driver for JUnit:
     "junit"                   % "junit-dep"       % "4.11"   % "test",
@@ -45,15 +45,12 @@ lazy val scalacOptionsAll = Seq(
   "-language:existentials",            // Existential types (besides wildcard types) can be written and inferred
   "-language:higherKinds",             // Allow higher-kinded types
   "-language:implicitConversions",     // Allow definition of implicit functions called views
-  "-Ywarn-infer-any",                  // Warn if Any is inferred for a type
   "-Ywarn-dead-code",                  // Warn when dead code is identified.
   "-Ywarn-numeric-widen",              // Warn when numerics are widened.
   "-Ywarn-value-discard",              // Warn when non-Unit expression results are unused.
   "-Xcheckinit",                       // Wrap field accessors to throw an exception on uninitialized access.
   "-Xfatal-warnings",                  // Fail the compilation if there are any warnings
-  "-Xfuture",                          // Turn on future language features.
   "-Xlint:adapted-args",               // Warn if an argument list is modified to match the receiver.
-  "-Xlint:by-name-right-associative",  // By-name parameter of right associative operator.
   "-Xlint:delayedinit-select",         // Selecting member of DelayedInit.
   "-Xlint:doc-detached",               // A Scaladoc comment appears to be detached from its element.
   "-Xlint:inaccessible",               // Warn about inaccessible types in method signatures.
@@ -66,8 +63,7 @@ lazy val scalacOptionsAll = Seq(
   "-Xlint:poly-implicit-overload",     // Parameterized overloaded implicit methods are not visible as view bounds.
   "-Xlint:private-shadow",             // A private field (or class parameter) shadows a superclass field.
   "-Xlint:stars-align",                // Pattern sequence wildcard must align with sequence component.
-  "-Xlint:type-parameter-shadow",      // A local type parameter shadows a type already in scope.
-  "-Xlint:unsound-match"               // Pattern match may not be typesafe.
+  "-Xlint:type-parameter-shadow"       // A local type parameter shadows a type already in scope.
 )
 lazy val scalacOptionsAllCompile = Seq(
   // "-Yno-imports"                    // Compile without importing scala.*, java.lang.*, or Predef
@@ -79,8 +75,12 @@ lazy val scalacOptionsAllConsole = Seq(
 
 lazy val scalacOptions11 = Seq(
   "-language:experimental.macros",
+  "-Xfuture",                          // Turn on future language features.
+  "-Xlint:by-name-right-associative",  // By-name parameter of right associative operator.
+  "-Xlint:unsound-match",              // Pattern match may not be typesafe.
   "-Ypartial-unification",             // Enable partial unification in type constructor inference
   "-Ywarn-unused-import",              // Warn when imports are unused
+  "-Ywarn-infer-any",                  // Warn if Any is inferred for a type
   "-optimise"
 ) ++ scalacOptionsAll
 
@@ -99,6 +99,10 @@ lazy val scalacOptions1213 = Seq(
 
 // Removed in Scala 2.13:
 lazy val scalacOptions12 = scalacOptions1213 ++ Seq(
+  "-Xfuture",                          // Turn on future language features.
+  "-Xlint:by-name-right-associative",  // By-name parameter of right associative operator.
+  "-Xlint:unsound-match",              // Pattern match may not be typesafe.
+  "-Ywarn-infer-any",                  // Warn if Any is inferred for a type
   "-Yno-adapted-args",                 // Do not adapt an argument list (either by inserting () or creating a tuple) to match the receiver.
   "-Ypartial-unification"              // Enable partial unification in type constructor inference
 )

--- a/src/main/scala/progscala2/concurrency/akka/AkkaClient.scala
+++ b/src/main/scala/progscala2/concurrency/akka/AkkaClient.scala
@@ -13,7 +13,7 @@ object AkkaClient {                                                  // <1>
   private var system: Option[ActorSystem] = None                     // <2>
 
   def main(args: Array[String]): Unit = {                            // <3>
-    processArgs(args)
+    processArgs(args.toIndexedSeq)
     val sys = ActorSystem("AkkaClient")                              // <4>
     system = Some(sys)
     val server = ServerActor.make(sys)                               // <5>

--- a/src/main/scala/progscala2/fp/categories/functor.scala
+++ b/src/main/scala/progscala2/fp/categories/functor.scala
@@ -1,6 +1,5 @@
 // src/main/scala/progscala2/fp/categories/Functor.scala
 package progscala2.fp.categories
-import scala.language.higherKinds
 
 trait Functor[F[_]] {                                                // <1>
   def map[A, B](fa: F[A])(f: A => B): F[B]                           // <2>

--- a/src/main/scala/progscala2/fp/categories/monad.scala
+++ b/src/main/scala/progscala2/fp/categories/monad.scala
@@ -1,6 +1,5 @@
 // src/main/scala/progscala2/fp/categories/Monad.scala
 package progscala2.fp.categories
-import scala.language.higherKinds
 
 trait Monad[M[_]] {                                                // <1>
   def flatMap[A, B](fa: M[A])(f: A => M[B]): M[B]                  // <2>

--- a/src/main/scala/progscala2/typesystem/higherkinded/reduce.scala
+++ b/src/main/scala/progscala2/typesystem/higherkinded/reduce.scala
@@ -1,6 +1,6 @@
 // src/main/scala/progscala2/typesystem/higherkinded/Reduce.scala
 package progscala2.typesystem.higherkinded
-import scala.language.higherKinds                                    // <1>
+// import scala.language.higherKinds                                 // <1>
 
 trait Reduce[T, -M[T]] {                                             // <2>
   def reduce(m: M[T])(f: (T, T) => T): T
@@ -12,6 +12,6 @@ object Reduce {                                                      // <3>
   }
 
   implicit def optionReduce[T] = new Reduce[T, Option] {
-    def reduce(opt: Option[T])(f: (T, T) => T): T = opt reduce f
+    def reduce(opt: Option[T])(f: (T, T) => T): T = opt.iterator reduce f
   }
 }

--- a/src/main/scala/progscala2/typesystem/higherkinded/reduce1.scala
+++ b/src/main/scala/progscala2/typesystem/higherkinded/reduce1.scala
@@ -1,6 +1,5 @@
 // src/main/scala/progscala2/typesystem/higherkinded/Reduce1.scala
 package progscala2.typesystem.higherkinded
-import scala.language.higherKinds
 
 trait Reduce1[-M[_]] {                                               // <1>
   def reduce[T](m: M[T])(f: (T, T) => T): T
@@ -12,6 +11,6 @@ object Reduce1 {                                                     // <2>
   }
 
   implicit val optionReduce = new Reduce1[Option] {
-    def reduce[T](opt: Option[T])(f: (T, T) => T): T = opt reduce f
+    def reduce[T](opt: Option[T])(f: (T, T) => T): T = opt.iterator reduce f
   }
 }

--- a/src/main/scala/progscala2/typesystem/typelambdas/Functor.scala
+++ b/src/main/scala/progscala2/typesystem/typelambdas/Functor.scala
@@ -1,6 +1,5 @@
 // src/main/scala/progscala2/typesystem/typelambdas/Functor.scala
 package progscala2.typesystem.typelambdas
-import scala.language.higherKinds
 
 trait Functor[A,+M[_]] {                                             // <1>
   def map2[B](f: A => B): M[B]

--- a/src/test/java/progscala2/javainterop/SMapTest.java
+++ b/src/test/java/progscala2/javainterop/SMapTest.java
@@ -6,12 +6,13 @@ import static org.junit.Assert.assertTrue;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.scalatestplus.junit.JUnitSuite;
 
 import scala.Option;
 import scala.collection.mutable.LinkedHashMap;
 
-public class SMapTest extends org.scalatest.junit.JUnitSuite {       // <1>
-  
+public class SMapTest extends JUnitSuite {       // <1>
+
 	// Apparently JUnitSuite is serializable, so we need this:
 	private static final long serialVersionUID = 693445694552874517L;
 

--- a/src/test/scala/progscala2/dsls/payroll/internal/DSLSpec.scala
+++ b/src/test/scala/progscala2/dsls/payroll/internal/DSLSpec.scala
@@ -3,11 +3,11 @@ package progscala2.dsls.payroll.internal
 import progscala2.dsls.payroll.common._
 import scala.language.postfixOps
 import org.scalatest.{FunSpec, Matchers}
-import org.scalatest.prop.Checkers._
+import org.scalatestplus.scalacheck.Checkers
 import org.scalacheck._
 
 // TODO: Really this should be a ScalaCheck properties test.
-class DSLSpec extends FunSpec with Matchers {
+class DSLSpec extends FunSpec with Matchers with Checkers {
   import dsl._
 
   val biweeklyDeductions = biweekly { deduct =>

--- a/src/test/scala/progscala2/dsls/payroll/parsercomb/DSLSpec.scala
+++ b/src/test/scala/progscala2/dsls/payroll/parsercomb/DSLSpec.scala
@@ -1,11 +1,11 @@
 // src/main/scala/progscala2/dsls/payroll/parsercomb/DSLSpec.scala
 package progscala2.dsls.payroll.parsercomb
 import org.scalatest.{FunSpec, Matchers}
-import org.scalatest.prop.Checkers._
+import org.scalatestplus.scalacheck.Checkers
 import org.scalacheck._
 
 // TODO: Really this should be a ScalaCheck properties test.
-class DSLSpec extends FunSpec with Matchers {
+class DSLSpec extends FunSpec with Matchers with Checkers {
   import dsl.PayrollParser
 
   val input = """biweekly {

--- a/src/test/scala/progscala2/fp/categories/FunctorProperties.scala
+++ b/src/test/scala/progscala2/fp/categories/FunctorProperties.scala
@@ -1,9 +1,9 @@
 // src/test/scala/progscala2/fp/categories/FunctorProperties.scala
 package progscala2.fp.categories
 import org.scalatest.FunSpec
-import org.scalatest.prop.PropertyChecks
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 
-class FunctorProperties extends FunSpec with PropertyChecks {
+class FunctorProperties extends FunSpec with ScalaCheckPropertyChecks {
 
   def id[A] = identity[A] _    // Lift identity method to a function
 

--- a/src/test/scala/progscala2/fp/categories/MonadProperties.scala
+++ b/src/test/scala/progscala2/fp/categories/MonadProperties.scala
@@ -1,9 +1,9 @@
 // src/test/scala/progscala2/fp/categories/MonadProperties.scala
 package progscala2.fp.categories
 import org.scalatest.FunSpec
-import org.scalatest.prop.PropertyChecks
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 
-class MonadProperties extends FunSpec with PropertyChecks {
+class MonadProperties extends FunSpec with ScalaCheckPropertyChecks {
 
   // Arbitrary function:
   val f1: Int => Seq[Int] = i => 0 until 10 by ((math.abs(i) % 10) + 1)

--- a/src/test/scala/progscala2/tools/ComplexProperties.scala
+++ b/src/test/scala/progscala2/tools/ComplexProperties.scala
@@ -1,9 +1,9 @@
 // src/main/scala/progscala2/toolslibs/toolslibs/ComplexProperties.scala
 package progscala2.toolslibs
 import org.scalatest.FunSuite
-import org.scalatest.prop.PropertyChecks
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 
-class ComplexProperties extends FunSuite with PropertyChecks {
+class ComplexProperties extends FunSuite with ScalaCheckPropertyChecks {
 
   def additionTest(a: Complex, b: Complex) = {
     assert( (a + b).real === (a.real + b.real) )


### PR DESCRIPTION
Thanks to Seth Tisue's suggestions for which version of ScalaTest to use, the code compiles and the tests succeed for Scala 2.11.12, 2.12.8, and 2.13.0-RC2.