### PR TITLE
Scala 2.13.1, SBT 1.3.2, ScalaTest 3.0.8, others

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -4,14 +4,15 @@
 
 *Dean Wampler*<br/>
 *August 11, 2014*<br/>
-*May 27, 2019* - Updated for Scala 2.12 and 2.13
-*June 18, 2019* - New support for Maven builds, courtesy of [oldbig](https://github.com/oldbig)
+*May 27, 2019* - Updated for Scala 2.12 and 2.13<br/>
+*June 18, 2019* - New support for Maven builds, courtesy of [oldbig](https://github.com/oldbig)<br/>
+*October 13, 2019* - Updated for Scala 2.13.1, sbt 1.3.2, and other updated dependencies. Also now compiles with JDK 11<br/>
 
 [![Join the chat at https://gitter.im/deanwampler/prog-scala-2nd-ed-code-examples](https://badges.gitter.im/deanwampler/prog-scala-2nd-ed-code-examples.svg)](https://gitter.im/deanwampler/prog-scala-2nd-ed-code-examples?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 This archive contains all the code examples found in [Programming Scala, Second Edition](http://shop.oreilly.com/product/0636920033073.do), with the exception of some trivial code snippets in the text. There are also some examples in this distribution that aren't actually in the book.
 
-When the book was published, the examples used Scala 2.11. The code was recently updated to also compile with Scala 2.12.8 and 2.13.0-RC2. The examples are mostly unchanged, except where necessary to compile with these newer versions and with the stricter compiler flags now used.
+When the book was published, the examples used Scala 2.11. The code was recently updated to also compile with Scala 2.12.10 and 2.13.1. The examples are mostly unchanged, except where necessary to compile with these newer versions and with the stricter compiler flags now used.
 
 If you want the original code (with a few bug fixes), download the tagged `2.1.0` build or check out the `release-2.1.0` branch. The `2.3.0` release and `release-2.3.0` branch include all the updates for 2.12 and 2.13.
 

--- a/build.sbt
+++ b/build.sbt
@@ -6,13 +6,14 @@ organization := "org.programming-scala"
 
 scalaVersion := "2.13.1"
 crossScalaVersions := Seq("2.11.12", "2.12.10", "2.13.1")
+maxErrors := 10
 
 libraryDependencies ++= {
   lazy val versions =
     CrossVersion.partialVersion(scalaVersion.value) match {
       case Some((2, 11)) => Map("async" -> "0.9.7",  "akka" -> "2.5.25")
       case Some((2, 12)) => Map("async" -> "0.10.0", "akka" -> "2.5.25")
-      case Some((2, 13)) => Map("async" -> "0.10.0", "akka" -> "2.6.0-M2")
+      case Some((2, 13)) => Map("async" -> "0.10.0", "akka" -> "2.6.0-M8")
       case Some((m, n))  => println(s"Unrecognized compiler version $m.$n"); sys.exit(1)
       case None          => println("CrossVersion.partialVersion(scalaVersion.value) returned None!!"); sys.exit(1)
     }
@@ -25,8 +26,8 @@ libraryDependencies ++= {
     "com.typesafe.akka"      %% "akka-slf4j"      % versions("akka"),
     "ch.qos.logback"          % "logback-classic" % "1.2.3",
     "org.scalaz"             %% "scalaz-core"     % "7.2.27",
-    "org.scalacheck"         %% "scalacheck"      % "1.14.0" % "test",
-    "org.scalatest"          %% "scalatest"       % "3.2.0-M1" % "test", // threading the needle on versions...
+    "org.scalacheck"         %% "scalacheck"      % "1.14.1" % "test",
+    "org.scalatest"          %% "scalatest"       % "3.0.8"  % "test", // threading the needle on versions...
     "org.specs2"             %% "specs2-core"     % "4.5.1"  % "test",
     "org.specs2"             %% "specs2-junit"    % "4.5.1"  % "test",
     // JUnit is used for some Java interop. examples. A driver for JUnit:

--- a/build.sbt
+++ b/build.sbt
@@ -26,7 +26,7 @@ libraryDependencies ++= {
     "ch.qos.logback"          % "logback-classic" % "1.2.3",
     "org.scalaz"             %% "scalaz-core"     % "7.2.27",
     "org.scalacheck"         %% "scalacheck"      % "1.14.0" % "test",
-    "org.scalatest"          %% "scalatest"       % "3.0.8-RC4" % "test", // threading the needle on versions...
+    "org.scalatest"          %% "scalatest"       % "3.2.0-M1" % "test", // threading the needle on versions...
     "org.specs2"             %% "specs2-core"     % "4.5.1"  % "test",
     "org.specs2"             %% "specs2-junit"    % "4.5.1"  % "test",
     // JUnit is used for some Java interop. examples. A driver for JUnit:

--- a/build.sbt
+++ b/build.sbt
@@ -1,17 +1,17 @@
 name := "Programming Scala, Second Edition - Code examples"
 
-version := "2.2"
+version := "2.3"
 
 organization := "org.programming-scala"
 
-scalaVersion := "2.12.8"
-crossScalaVersions := Seq("2.11.12", "2.12.8", "2.13.0-RC2")
+scalaVersion := "2.13.1"
+crossScalaVersions := Seq("2.11.12", "2.12.10", "2.13.1")
 
 libraryDependencies ++= {
   lazy val versions =
     CrossVersion.partialVersion(scalaVersion.value) match {
-      case Some((2, 11)) => Map("async" -> "0.9.7",  "akka" -> "2.5.22")
-      case Some((2, 12)) => Map("async" -> "0.10.0", "akka" -> "2.5.22")
+      case Some((2, 11)) => Map("async" -> "0.9.7",  "akka" -> "2.5.25")
+      case Some((2, 12)) => Map("async" -> "0.10.0", "akka" -> "2.5.25")
       case Some((2, 13)) => Map("async" -> "0.10.0", "akka" -> "2.6.0-M2")
       case Some((m, n))  => println(s"Unrecognized compiler version $m.$n"); sys.exit(1)
       case None          => println("CrossVersion.partialVersion(scalaVersion.value) returned None!!"); sys.exit(1)

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.0-RC1
+sbt.version=1.3.2

--- a/src/test/scala/progscala2/dsls/payroll/internal/DSLSpec.scala
+++ b/src/test/scala/progscala2/dsls/payroll/internal/DSLSpec.scala
@@ -2,12 +2,13 @@
 package progscala2.dsls.payroll.internal
 import progscala2.dsls.payroll.common._
 import scala.language.postfixOps
-import org.scalatest.{FunSpec, Matchers}
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.scalacheck.Checkers
 import org.scalacheck._
 
 // TODO: Really this should be a ScalaCheck properties test.
-class DSLSpec extends FunSpec with Matchers with Checkers {
+class DSLSpec extends AnyFunSpec with Matchers with Checkers {
   import dsl._
 
   val biweeklyDeductions = biweekly { deduct =>

--- a/src/test/scala/progscala2/dsls/payroll/internal/DSLSpec.scala
+++ b/src/test/scala/progscala2/dsls/payroll/internal/DSLSpec.scala
@@ -2,13 +2,14 @@
 package progscala2.dsls.payroll.internal
 import progscala2.dsls.payroll.common._
 import scala.language.postfixOps
-import org.scalatest.funspec.AnyFunSpec
-import org.scalatest.matchers.should.Matchers
+import org.scalatest.FunSpec
+import org.scalatest.Matchers
+import org.scalatest.prop._
 import org.scalatestplus.scalacheck.Checkers
-import org.scalacheck._
+import org.scalacheck.{Gen, Prop}
 
 // TODO: Really this should be a ScalaCheck properties test.
-class DSLSpec extends AnyFunSpec with Matchers with Checkers {
+class DSLSpec extends FunSpec with Matchers with Checkers {
   import dsl._
 
   val biweeklyDeductions = biweekly { deduct =>

--- a/src/test/scala/progscala2/dsls/payroll/parsercomb/DSLSpec.scala
+++ b/src/test/scala/progscala2/dsls/payroll/parsercomb/DSLSpec.scala
@@ -1,12 +1,13 @@
 // src/main/scala/progscala2/dsls/payroll/parsercomb/DSLSpec.scala
 package progscala2.dsls.payroll.parsercomb
-import org.scalatest.funspec.AnyFunSpec
-import org.scalatest.matchers.should.Matchers
+import org.scalatest.FunSpec
+import org.scalatest.Matchers
+import org.scalatest.prop._
 import org.scalatestplus.scalacheck.Checkers
-import org.scalacheck._
+import org.scalacheck.{Gen, Prop}
 
 // TODO: Really this should be a ScalaCheck properties test.
-class DSLSpec extends AnyFunSpec with Matchers with Checkers {
+class DSLSpec extends FunSpec with Matchers with Checkers {
   import dsl.PayrollParser
 
   val input = """biweekly {

--- a/src/test/scala/progscala2/dsls/payroll/parsercomb/DSLSpec.scala
+++ b/src/test/scala/progscala2/dsls/payroll/parsercomb/DSLSpec.scala
@@ -1,11 +1,12 @@
 // src/main/scala/progscala2/dsls/payroll/parsercomb/DSLSpec.scala
 package progscala2.dsls.payroll.parsercomb
-import org.scalatest.{FunSpec, Matchers}
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.scalacheck.Checkers
 import org.scalacheck._
 
 // TODO: Really this should be a ScalaCheck properties test.
-class DSLSpec extends FunSpec with Matchers with Checkers {
+class DSLSpec extends AnyFunSpec with Matchers with Checkers {
   import dsl.PayrollParser
 
   val input = """biweekly {

--- a/src/test/scala/progscala2/fp/categories/FunctorProperties.scala
+++ b/src/test/scala/progscala2/fp/categories/FunctorProperties.scala
@@ -1,9 +1,9 @@
 // src/test/scala/progscala2/fp/categories/FunctorProperties.scala
 package progscala2.fp.categories
-import org.scalatest.FunSpec
+import org.scalatest.funspec.AnyFunSpec
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 
-class FunctorProperties extends FunSpec with ScalaCheckPropertyChecks {
+class FunctorProperties extends AnyFunSpec with ScalaCheckPropertyChecks {
 
   def id[A] = identity[A] _    // Lift identity method to a function
 

--- a/src/test/scala/progscala2/fp/categories/FunctorProperties.scala
+++ b/src/test/scala/progscala2/fp/categories/FunctorProperties.scala
@@ -1,9 +1,9 @@
 // src/test/scala/progscala2/fp/categories/FunctorProperties.scala
 package progscala2.fp.categories
-import org.scalatest.funspec.AnyFunSpec
-import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+import org.scalatest.FunSpec
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 
-class FunctorProperties extends AnyFunSpec with ScalaCheckPropertyChecks {
+class FunctorProperties extends FunSpec with ScalaCheckDrivenPropertyChecks {
 
   def id[A] = identity[A] _    // Lift identity method to a function
 

--- a/src/test/scala/progscala2/fp/categories/MonadProperties.scala
+++ b/src/test/scala/progscala2/fp/categories/MonadProperties.scala
@@ -1,9 +1,9 @@
 // src/test/scala/progscala2/fp/categories/MonadProperties.scala
 package progscala2.fp.categories
-import org.scalatest.FunSpec
+import org.scalatest.funspec.AnyFunSpec
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 
-class MonadProperties extends FunSpec with ScalaCheckPropertyChecks {
+class MonadProperties extends AnyFunSpec with ScalaCheckPropertyChecks {
 
   // Arbitrary function:
   val f1: Int => Seq[Int] = i => 0 until 10 by ((math.abs(i) % 10) + 1)

--- a/src/test/scala/progscala2/fp/categories/MonadProperties.scala
+++ b/src/test/scala/progscala2/fp/categories/MonadProperties.scala
@@ -1,9 +1,9 @@
 // src/test/scala/progscala2/fp/categories/MonadProperties.scala
 package progscala2.fp.categories
-import org.scalatest.funspec.AnyFunSpec
-import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+import org.scalatest.FunSpec
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 
-class MonadProperties extends AnyFunSpec with ScalaCheckPropertyChecks {
+class MonadProperties extends FunSpec with ScalaCheckDrivenPropertyChecks {
 
   // Arbitrary function:
   val f1: Int => Seq[Int] = i => 0 until 10 by ((math.abs(i) % 10) + 1)

--- a/src/test/scala/progscala2/metaprogramming/InvariantSpec.scala
+++ b/src/test/scala/progscala2/metaprogramming/InvariantSpec.scala
@@ -1,8 +1,8 @@
 // src/test/scala/progscala2/metaprogramming/InvariantSpec.scala
 package metaprogramming
-import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.FunSpec
 
-class InvariantSpec extends AnyFunSpec {
+class InvariantSpec extends FunSpec {
   case class Variable(var i: Int, var s: String)
 
   describe ("invariant.apply") {

--- a/src/test/scala/progscala2/metaprogramming/InvariantSpec.scala
+++ b/src/test/scala/progscala2/metaprogramming/InvariantSpec.scala
@@ -1,8 +1,8 @@
 // src/test/scala/progscala2/metaprogramming/InvariantSpec.scala
 package metaprogramming
-import org.scalatest.FunSpec
+import org.scalatest.funspec.AnyFunSpec
 
-class InvariantSpec extends FunSpec {
+class InvariantSpec extends AnyFunSpec {
   case class Variable(var i: Int, var s: String)
 
   describe ("invariant.apply") {

--- a/src/test/scala/progscala2/tools/ComplexProperties.scala
+++ b/src/test/scala/progscala2/tools/ComplexProperties.scala
@@ -1,9 +1,9 @@
 // src/main/scala/progscala2/toolslibs/toolslibs/ComplexProperties.scala
 package progscala2.toolslibs
 import org.scalatest.FunSuite
-import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 
-class ComplexProperties extends FunSuite with ScalaCheckPropertyChecks {
+class ComplexProperties extends FunSuite with ScalaCheckDrivenPropertyChecks {
 
   def additionTest(a: Complex, b: Complex) = {
     assert( (a + b).real === (a.real + b.real) )

--- a/src/test/scala/progscala2/tools/ComplexSpec.scala
+++ b/src/test/scala/progscala2/tools/ComplexSpec.scala
@@ -1,8 +1,9 @@
 // src/test/scala/progscala2/toolslibs/ComplexSpec.scala
 package progscala2.toolslibs
-import org.scalatest.{ FunSpec, Matchers }
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 
-class ComplexSpec extends FunSpec with Matchers {
+class ComplexSpec extends AnyFunSpec with Matchers {
   describe ("Complex addition with (0.0, 0.0)") {
     it ("returns a number N' that is identical to original number N") {
       val c1 = Complex(1.2, 3.4)

--- a/src/test/scala/progscala2/tools/ComplexSpec.scala
+++ b/src/test/scala/progscala2/tools/ComplexSpec.scala
@@ -1,9 +1,9 @@
 // src/test/scala/progscala2/toolslibs/ComplexSpec.scala
 package progscala2.toolslibs
-import org.scalatest.funspec.AnyFunSpec
-import org.scalatest.matchers.should.Matchers
+import org.scalatest.FunSpec
+import org.scalatest.Matchers
 
-class ComplexSpec extends AnyFunSpec with Matchers {
+class ComplexSpec extends FunSpec with Matchers {
   describe ("Complex addition with (0.0, 0.0)") {
     it ("returns a number N' that is identical to original number N") {
       val c1 = Complex(1.2, 3.4)

--- a/src/test/scala/progscala2/typesystem/bounds/list/AbbrevListSpec.scala
+++ b/src/test/scala/progscala2/typesystem/bounds/list/AbbrevListSpec.scala
@@ -1,9 +1,10 @@
 // src/test/scala/progscala2/typesystem/bounds/list/AbbrevListSpec.scala
 package progscala2.typesystem.bounds.list
-import org.scalatest.{ FunSpec, Matchers }
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 
 /** Test the example "AbbrevList". Not very comprehensive... */
-class AbbrevListSpec extends FunSpec with Matchers {
+class AbbrevListSpec extends AnyFunSpec with Matchers {
 
   describe ("AbbrevNil") {
     it ("item :: AbbrevNil == AbbrevList(item)") {

--- a/src/test/scala/progscala2/typesystem/bounds/list/AbbrevListSpec.scala
+++ b/src/test/scala/progscala2/typesystem/bounds/list/AbbrevListSpec.scala
@@ -1,10 +1,10 @@
 // src/test/scala/progscala2/typesystem/bounds/list/AbbrevListSpec.scala
 package progscala2.typesystem.bounds.list
-import org.scalatest.funspec.AnyFunSpec
-import org.scalatest.matchers.should.Matchers
+import org.scalatest.FunSpec
+import org.scalatest.Matchers
 
 /** Test the example "AbbrevList". Not very comprehensive... */
-class AbbrevListSpec extends AnyFunSpec with Matchers {
+class AbbrevListSpec extends FunSpec with Matchers {
 
   describe ("AbbrevNil") {
     it ("item :: AbbrevNil == AbbrevList(item)") {


### PR DESCRIPTION
Bumped versions to final release versions of Scala, SBT, and ScalaTest. The ScalaTest version 3.0.8 required some changes to import statements and mixin traits used, as names changed, etc., but all the code in the tests did not require changes.